### PR TITLE
Background - Add raw support for background colors

### DIFF
--- a/src/renderer/Scene.tsx
+++ b/src/renderer/Scene.tsx
@@ -12,6 +12,7 @@ export default class Scene {
   horizTransType = HTF.none;
   vertTransType = VTF.none;
   crossFade = false;
+  backgroundColor = "";  //Color name of number Empty - use blurred image 
   playFullGif = false;
   textKind: string = "";
   textSource: string = "";

--- a/src/renderer/components/player/HeadlessScenePlayer.tsx
+++ b/src/renderer/components/player/HeadlessScenePlayer.tsx
@@ -154,6 +154,7 @@ export default class HeadlessScenePlayer extends React.Component {
             timingFunction={this.props.scene.timingFunction}
             timingConstant={this.props.scene.timingConstant}
             zoomType={this.props.scene.zoomType}
+            backgroundColor = {this.props.scene.backgroundColor}
             effectLevel={this.props.scene.effectLevel}
             horizTransType={this.props.scene.horizTransType}
             vertTransType={this.props.scene.vertTransType}

--- a/src/renderer/components/player/ImagePlayer.tsx
+++ b/src/renderer/components/player/ImagePlayer.tsx
@@ -7,6 +7,7 @@ import fs from "fs";
 import gifInfo from 'gif-info';
 import ChildCallbackHack from './ChildCallbackHack';
 import urlToPath from '../../urlToPath';
+import { isNull, isNullOrUndefined } from 'util';
 
 function choice<T>(items: Array<T>): T {
   const i = Math.floor(Math.random() * items.length);
@@ -24,6 +25,7 @@ export default class ImagePlayer extends React.Component {
     timingFunction: string,
     timingConstant: string,
     zoomType: string,
+    backgroundColor : string;  // color name or number - if empty string use blurred image
     effectLevel: number,
     horizTransType: string,
     vertTransType: string,
@@ -107,12 +109,19 @@ export default class ImagePlayer extends React.Component {
         className += `zoom-out-${this.props.effectLevel}s`;
     }
 
+
+    let backgroundDiv;
+    switch (this.props.backgroundColor) {
+      case '':
+        backgroundDiv = <div className="u-fill-container u-fill-image-blur" style={{ backgroundImage: `url("${imgs[0].src}")`, }}></div>;
+        break;
+      default:
+        backgroundDiv = <div className="u-fill-container" style={{ background: this.props.backgroundColor, }}></div>;
+    }
+
     return (
       <div className={className}>
-        <div className="u-fill-container u-fill-image-blur" style={{
-          backgroundImage: `url("${imgs[0].src}")`,
-        }}>
-        </div>
+        {backgroundDiv}
         {imgs.map((img) => {
           return <ImageView
             img={img}

--- a/src/renderer/components/sceneDetail/EffectGroup.tsx
+++ b/src/renderer/components/sceneDetail/EffectGroup.tsx
@@ -5,6 +5,7 @@ import ControlGroup from "./ControlGroup";
 import Scene from "../../Scene";
 import SimpleSliderInput from "../ui/SimpleSliderInput";
 import SimpleCheckbox from "../ui/SimpleCheckbox";
+import SimpleTextInput from "../ui/SimpleTextInput";
 
 export default class EffectGroup extends React.Component {
   readonly props: {
@@ -15,46 +16,52 @@ export default class EffectGroup extends React.Component {
 
   render() {
     return (
-        <ControlGroup title="Effects" isNarrow={true}>
-          <SimpleCheckbox
-            text="Cross-fade images"
-            isOn={this.props.scene.crossFade}
-            onChange={this.onChangeCrossFade.bind(this)} />
+      <ControlGroup title="Effects" isNarrow={true}>
+        <SimpleCheckbox
+          text="Cross-fade images"
+          isOn={this.props.scene.crossFade}
+          onChange={this.onChangeCrossFade.bind(this)} />
 
-          <div className="ControlSubgroup">
-            <SimpleOptionPicker
-              onChange={this.onChangeZoomType.bind(this)}
-              label="Zoom Type"
-              value={this.props.scene.zoomType}
-              keys={Object.values(ZF)} />
-            <SimpleSliderInput
-              isEnabled={true}
-              onChange={this.onChangeEffectLevel.bind(this)}
-              label={"Effect Length: " + this.props.scene.effectLevel + "s"}
-              min={1}
-              max={20}
-              value={this.props.scene.effectLevel.toString()} />
-            <SimpleOptionPicker
-              onChange={this.onChangeHorizTransType.bind(this)}
-              label="Translate Horizontally"
-              value={this.props.scene.horizTransType}
-              keys={Object.values(HTF)} />
-            <SimpleOptionPicker
-              onChange={this.onChangeVertTransType.bind(this)}
-              label="Translate Vertically"
-              value={this.props.scene.vertTransType}
-              keys={Object.values(VTF)} />
-          </div>
+        <SimpleTextInput
+          isEnabled= {true}
+          onChange={this.onChangeBackgroundColor.bind(this)}
+          label="Background color"
+          value={this.props.scene.backgroundColor.toString()} />
 
-          <div className="ControlSubgroup">
-            {this.props.allScenes != null && (
+        <div className="ControlSubgroup">
+          <SimpleOptionPicker
+            onChange={this.onChangeZoomType.bind(this)}
+            label="Zoom Type"
+            value={this.props.scene.zoomType}
+            keys={Object.values(ZF)} />
+          <SimpleSliderInput
+            isEnabled={true}
+            onChange={this.onChangeEffectLevel.bind(this)}
+            label={"Effect Length: " + this.props.scene.effectLevel + "s"}
+            min={1}
+            max={20}
+            value={this.props.scene.effectLevel.toString()} />
+          <SimpleOptionPicker
+            onChange={this.onChangeHorizTransType.bind(this)}
+            label="Translate Horizontally"
+            value={this.props.scene.horizTransType}
+            keys={Object.values(HTF)} />
+          <SimpleOptionPicker
+            onChange={this.onChangeVertTransType.bind(this)}
+            label="Translate Vertically"
+            value={this.props.scene.vertTransType}
+            keys={Object.values(VTF)} />
+        </div>
+
+        <div className="ControlSubgroup">
+          {this.props.allScenes != null && (
             <SimpleOptionPicker
               onChange={this.onChangeOverlaySceneID.bind(this)}
               label="Overlay scene"
               value={this.props.scene.overlaySceneID.toString()}
               getLabel={this.getSceneName.bind(this)}
               keys={["0"].concat(this.props.allScenes.map((s) => s.id.toString()))} />)}
-            {(this.props.allScenes != null || this.props.scene.overlaySceneID != 0) && (
+          {(this.props.allScenes != null || this.props.scene.overlaySceneID != 0) && (
             <SimpleSliderInput
               isEnabled={this.props.scene.overlaySceneID != 0}
               onChange={this.onChangeOverlaySceneOpacity.bind(this)}
@@ -62,8 +69,8 @@ export default class EffectGroup extends React.Component {
               min={1}
               max={99}
               value={(this.props.scene.overlaySceneOpacity * 100).toString()} />)}
-          </div>
-        </ControlGroup>
+        </div>
+      </ControlGroup>
     );
   }
 
@@ -89,4 +96,6 @@ export default class EffectGroup extends React.Component {
   onChangeOverlaySceneOpacity(value: string) { this.update((s) => { s.overlaySceneOpacity = parseInt(value, 10) / 100; }); }
 
   onChangeOverlaySceneID(id: string) { this.update((s) => { s.overlaySceneID = parseInt(id, 10); }); }
+
+  onChangeBackgroundColor(type: string) { this.update((s) => { s.backgroundColor = type; }); }
 }


### PR DESCRIPTION
in answer to: https://github.com/ififfy/flipflip/issues/86

These changes are the first steps to additionally support a background color as an alternative to a background scaled and blurred image.

In the Scene Detail it adds a text control into which a color name e.g. "black" can be entered or alternatively a color number say "#ff00ff"  to configure a fixed background color.

If the background color text control is left empty then the default blurred scaled image is used for the background.

ToDo:

I think I should extend this to provide a color palete picker rather than leave free text entry of the color - but this is a first step...

